### PR TITLE
feat: highlight unknown transactions in transactions page

### DIFF
--- a/internal/api/transactions.html
+++ b/internal/api/transactions.html
@@ -30,7 +30,7 @@
     </thead>
     <tbody>
       {{ range .Transactions }}
-      <tr>
+      <tr class="{{ if eq .CategoryName "Unknown" }}table-warning{{ end }}">
         <td><a href="#"
           hx-get="/transactionForm?id={{ .ID }}"
           hx-trigger="click"

--- a/internal/api/transactions.html
+++ b/internal/api/transactions.html
@@ -42,7 +42,11 @@
         <td>{{ .Description }}</td>
         <td style="text-align: right;">${{ .Amount }}</td>
         <td>{{ .AccountName }}</td>
-        <td>{{ .CategoryName }}</td>
+        <td>{{ .CategoryName }}
+        {{ if eq .CategoryName "Unknown" }}
+          <span class="badge bg-warning text-dark">⚠️ Category needs review</span>
+        {{ end }}
+        </td>
         <td>{{ .Excluded }}</td>
         <td>{{ .ImportSubmissionID }}</td>
       </tr>


### PR DESCRIPTION
This PR adds the bootstrap class `table-warning` if a transaction category is `Unknown` 

This helps a user to find transactions that should get updated

ref: #47 
## Demo
<img width="1338" alt="image" src="https://github.com/user-attachments/assets/ad70931b-5259-407b-8ef7-5ebcb467ce68" />
