### PR TITLE
feat: add hx-confirm for delete confirmation

### DIFF
--- a/internal/api/transactionForm.html
+++ b/internal/api/transactionForm.html
@@ -66,6 +66,7 @@
   {{ if eq .Editing true }}
   <button type="submit" class="btn btn-danger"
     hx-delete="/transactions"
+    hx-confirm="Are you sure you want to delete this transaction?"
     hx-trigger="click"
     hx-target="#reportContent"
     hx-swap="innerHTML">


### PR DESCRIPTION
This PR adds the [htmx-confirm](https://htmx.org/attributes/hx-confirm/) attribute for extra security against unwanted deletes

demo:
<img width="968" alt="image" src="https://github.com/user-attachments/assets/ac97d4d5-b062-4a56-b222-bf6376c25997" />

ref: #57 
