### PR TITLE
Padding "decimal strings"

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -24,16 +24,37 @@ func StringToUint(input string) (uint, error) {
 	return uint(output), nil
 }
 
+// Convert whole cents (as int) to dollars (as float64) and returns a "commaized" string
 func CentsToDollarStringHumanized(input int) string {
-	// Convert whole cents (as int) to dollars (as float64)
 	amount := float64(input) / 100
-	return humanize.CommafWithDigits(amount, 2)
+	return trimTrailingDigits(humanize.Commaf(amount), 2)
 }
 
+// Convert whole cents (as int) to dollars (as float64) and returns a string
 func CentsToDollarStringMachineSafe(input int) string {
-	// Convert whole cents (as int) to dollars (as float64)
 	amount := float64(input) / 100
 	return fmt.Sprintf("%.2f", amount)
+}
+
+// Trims digits following decimal place in "number strings"
+func trimTrailingDigits(s string, digits int) string {
+	if digits <= 0 {
+		return s
+	}
+	if i := strings.Index(s, "."); i >= 0 {
+		if len(s[i+1:]) < digits {
+			return s + strings.Repeat("0", digits-len(s[i+1:]))
+		}
+		if digits <= 0 {
+			return s[:i]
+		}
+		i++
+		if i+digits >= len(s) {
+			return s
+		}
+		return s[:i+digits]
+	}
+	return s + "." + strings.Repeat("0", digits)
 }
 
 func DollarStringToCents(input string) int {

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -32,3 +32,65 @@ func TestPercentile(t *testing.T) {
 		}
 	}
 }
+
+func TestCentsToDollarStringHumanized(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    int
+		expected string
+	}{
+		{"1", 1, "0.01"},
+		{"10", 10, "0.10"},
+		{"100", 100, "1.00"},
+		{"1000", 1000, "10.00"},
+		{"10000", 10000, "100.00"},
+		{"100000", 100000, "1,000.00"},
+		{"1000000", 1000000, "10,000.00"},
+		{"90", 90, "0.90"},
+		{"115", 115, "1.15"},
+		{"107", 107, "1.07"},
+		{"14.5", 145, "14.5"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			result := CentsToDollarStringHumanized(test.input)
+			if result != test.expected {
+				t.Errorf("CentsToDollarStringHumanized(%v) = %s; expected %s", test.input, result, test.expected)
+			}
+		})
+	}
+
+}
+
+func TestTrimTrailingDigits(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		inputString string
+		inputDigits int
+		expected    string
+	}{
+		{"1.00", 2, "1.00"},
+		{"0.90", 2, "0.90"},
+		{"1.115", 2, "1.11"},
+		{"1.107", 2, "1.10"},
+		{"2.1", 2, "2.10"},
+		{"2", 2, "2.00"},
+		{"2", 10, "2.0000000000"},
+		{"1", 0, "1"},
+		{"1", -1, "1"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.inputString, func(t *testing.T) {
+			t.Parallel()
+			result := trimTrailingDigits(test.inputString, test.inputDigits)
+			if result != test.expected {
+				t.Errorf("trimTrailingDigits(%s, %d) = %s; expected %s", test.inputString, test.inputDigits, result, test.expected)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
Fixes #50 

Trims "decimal strings" to the given number of decimal places, adds padding "0" to strings after the decimal places where required.

This can probably be improved on - I've been looking at it for too long