### PR TITLE
Fix/65 category shows as having a budget after budget is deleted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,17 +5,17 @@ go 1.23.0
 toolchain go1.23.2
 
 require (
+	github.com/GopherML/bag v1.0.1
 	github.com/dustin/go-humanize v1.0.1
+	gonum.org/v1/gonum v0.16.0
 	gopkg.in/natefinch/lumberjack.v2 v2.2.1
 	gorm.io/driver/sqlite v1.5.6
 	gorm.io/gorm v1.25.10
 )
 
 require (
-	github.com/GopherML/bag v1.0.1 // indirect
 	github.com/go-yaml/yaml v2.1.0+incompatible // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
 	github.com/mattn/go-sqlite3 v1.14.22 // indirect
-	gonum.org/v1/gonum v0.16.0 // indirect
 )

--- a/internal/models/category.go
+++ b/internal/models/category.go
@@ -34,8 +34,9 @@ func (cr *CategoryRepository) GetAllCategoriesAndBudgetStatus() (categories []Ca
 			ELSE false
 		END AS has_budget
 		FROM categories c
-		LEFT JOIN budgets b ON c.ID = b.category_id
+		LEFT JOIN budgets b ON c.ID = b.category_id and b.deleted_at IS NULL
 		WHERE c.deleted_at IS NULL;`).Scan(&categories)
+	// Debug: Print account before saving
 	return categories, nil
 }
 


### PR DESCRIPTION
Fixed an issue where categories were incorrectly shown as having an active budget, even after the associated budget was soft-deleted.

**Changes Made:**

- Updated the SQL query in `GetAllCategoriesAndBudgetStatus()` to exclude soft-deleted budgets by adding a condition `b.deleted_at IS NULL` in the `LEFT JOIN` clause.
- Ensured that `HasBudget` is only marked `true` for categories with at least one non-deleted budget.
- No change to existing logic or structure — only improved the accuracy of the budget status.

**Why It Matters:**

This resolves incorrect UI/API behavior and ensures budget status accurately reflects the current data, preventing confusion during budget management.
