### PR TITLE
fix: Correct category budget status after budget deletion (#65)

### DIFF
--- a/internal/models/category.go
+++ b/internal/models/category.go
@@ -34,7 +34,7 @@ func (cr *CategoryRepository) GetAllCategoriesAndBudgetStatus() (categories []Ca
 			ELSE false
 		END AS has_budget
 		FROM categories c
-		LEFT JOIN budgets b ON c.ID = b.category_id
+		LEFT JOIN budgets b ON c.ID = b.category_id and b.deleted_at IS NULL
 		WHERE c.deleted_at IS NULL;`).Scan(&categories)
 	return categories, nil
 }


### PR DESCRIPTION
Fixed an issue where categories were incorrectly shown as having an active budget, even after the associated budget was soft-deleted.

**Changes Made:**

- Updated the SQL query in `GetAllCategoriesAndBudgetStatus()` to exclude soft-deleted budgets by adding a condition `b.deleted_at IS NULL` in the `LEFT JOIN` clause.
- Ensured that `HasBudget` is only marked `true` for categories with at least one non-deleted budget.
- No change to existing logic or structure — only improved the accuracy of the budget status.

**Why It Matters:**

This resolves incorrect UI/API behavior and ensures budget status accurately reflects the current data, preventing confusion during budget management.