### PR TITLE
chore: fixes logger test that failed in CI

### DIFF
--- a/internal/utils/logger/logger_test.go
+++ b/internal/utils/logger/logger_test.go
@@ -35,9 +35,6 @@ type logMesaage struct {
 func TestErrorLog(t *testing.T) {
 	buf := &bytes.Buffer{}
 
-	// Redirect STDOUT to a buffer
-	stdout := os.Stdout
-
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Errorf("Failed to redirect STDOUT")
@@ -54,10 +51,6 @@ func TestErrorLog(t *testing.T) {
 
 	logger := logger.Get()
 	logger.Error("Error log")
-
-	// Reset output
-	w.Close()
-	os.Stdout = stdout
 
 	// Test output
 	t.Log(buf)
@@ -88,5 +81,6 @@ func TestErrorLog(t *testing.T) {
 		if err := os.RemoveAll(path.Join(cwd, "/logs")); err != nil {
 			log.Printf("ERROR: Removing test log folder: %v %s", err, cwd)
 		}
+		w.Close()
 	})
 }


### PR DESCRIPTION
removed some extraneous variables that didn't seem necessary to the logger_test and moved the `w.Close()` call to the cleanup function to ensure that the write pipe wasn't being prematurely closed. seems to have fixed the error in the tests