### PR TITLE
fix: set CGO_ENABLED in build process to ensure go-sqlite3 works

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -11,6 +11,7 @@ on:
 env:
   GO_VERSION: stable
   GOLANGCI_LINT_VERSION: v1.64
+  CGO_ENABLED: 1
 
 permissions:
   contents: read


### PR DESCRIPTION
previous builds would error on launch with the following error:

```
2025/07/04 14:19:00 /home/runner/work/sage/sage/internal/dependencyregistry/dependencyregistry.go:79
[error] failed to initialize database, got error Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work. This is a stub
panic: failed to get database connection
```
