### PR TITLE
76 interest rate for liability accounts

### DIFF
--- a/internal/api/accountForm.html
+++ b/internal/api/accountForm.html
@@ -1,49 +1,105 @@
 {{ template "header" .}}
 <div class="row">
-  <div class="col-sm-4">
-    <h2>{{ if eq .Updating true }}Update{{ else }}Add{{ end }} Account</h2>
-  </div>
+    <div class="col-sm-4">
+        <h2>{{ if eq .Updating true }}Update{{ else }}Add{{ end }} Account</h2>
+    </div>
 </div>
 
 <form hx-post="/account" hx-target="body" enctype="multipart/form-data">
-  <div class="row">
-    <div class="col-sm-6">
-      <div class="form-floating mb-3">
-        <input type="text" class="form-control" id="accountID" name="accountID" style="display:none;" value="{{ .AccountID }}">
-        <input type="text" class="form-control" id="accountName" name="accountName" value="{{ .AccountName }}">
-        <label for="accountName" class="form-label">Account Name</label>
-      </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <div class="form-floating mb-3">
+                <input
+                    type="text"
+                    class="form-control"
+                    id="accountID"
+                    name="accountID"
+                    style="display: none"
+                    value="{{ .AccountID }}"
+                />
+                <input
+                    type="text"
+                    class="form-control"
+                    id="accountName"
+                    name="accountName"
+                    value="{{ .AccountName }}"
+                />
+                <label for="accountName" class="form-label">Account Name</label>
+            </div>
+        </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-sm-6">
-      <div class="form-floating mb-3">
-        <select class="form-select" aria-label="account type selector" name="accountTypeID" id="accountTypeID">
-          {{range $i, $accountType := .AccountTypes}}
-          <option {{ if eq $.AccountTypeName $accountType.Name }}selected{{ end }} value="{{ $accountType.ID }}">{{ $accountType.Name }}</option>
-          {{ end }}
-        </select>
-        <label for="accountType" class="form-label">Account Type</label>
-      </div>
+    <div class="row">
+        <div class="col-sm-6">
+            <div class="form-floating mb-3">
+                <select
+                    class="form-select"
+                    aria-label="account type selector"
+                    name="accountTypeID"
+                    id="accountTypeID"
+                >
+                    {{range $i, $accountType := .AccountTypes}}
+                    <option
+                        {{
+                        if
+                        eq
+                        $.AccountTypeName
+                        $accountType.Name
+                        }}selected{{
+                        end
+                        }}
+                        value="{{ $accountType.ID }}"
+                    >
+                        {{ $accountType.Name }}
+                    </option>
+                    {{ end }}
+                </select>
+                <label for="accountType" class="form-label">Account Type</label>
+            </div>
+        </div>
     </div>
-  </div>
-  <button type="submit" class="btn btn-success"
-    hx-post="/accounts"
-    hx-trigger="click"
-    hx-target="body"
-    hx-swap="innerHTML">
-    Save
-  </button>
-  {{ if eq .Updating true }}
-  <button type="button" class="btn btn-danger"
-    hx-confirm="Are you sure you want to delete this account? All associated balances and transactions will be deleted."
-    hx-delete="/accounts"
-    hx-trigger="click"
-    hx-target="body"
-    hx-swap="innerHTML">
-      Delete
-  </button>
-  {{ end }}
-  <a type="button" class="btn btn-light" href="/accounts">Cancel</a>
+    <div class="row">
+        <div class="col-sm-6">
+            <div class="form-floating mb-3">
+                <input
+                    type="number"
+                    class="form-control"
+                    id="interestRate"
+                    name="interestRate"
+                    value="{{ .InterestRate }}"
+                    step="0.01"
+                    min="0"
+                    max="100"
+                    placeholder="0.00"
+                />
+                <label for="interestRate" class="form-label"
+                    >Interest Rate (%)</label
+                >
+            </div>
+        </div>
+    </div>
+    <button
+        type="submit"
+        class="btn btn-success"
+        hx-post="/accounts"
+        hx-trigger="click"
+        hx-target="body"
+        hx-swap="innerHTML"
+    >
+        Save
+    </button>
+    {{ if eq .Updating true }}
+    <button
+        type="button"
+        class="btn btn-danger"
+        hx-confirm="Are you sure you want to delete this account? All associated balances and transactions will be deleted."
+        hx-delete="/accounts"
+        hx-trigger="click"
+        hx-target="body"
+        hx-swap="innerHTML"
+    >
+        Delete
+    </button>
+    {{ end }}
+    <a type="button" class="btn btn-light" href="/accounts">Cancel</a>
 </form>
 {{ template "footer"}}

--- a/internal/api/accountForm.html
+++ b/internal/api/accountForm.html
@@ -48,6 +48,7 @@
                         end
                         }}
                         value="{{ $accountType.ID }}"
+                        data-ledger-type="{{ $accountType.LedgerType }}"
                     >
                         {{ $accountType.Name }}
                     </option>
@@ -57,7 +58,7 @@
             </div>
         </div>
     </div>
-    <div class="row">
+    <div class="row" id="interestRateRow" style="display: none">
         <div class="col-sm-6">
             <div class="form-floating mb-3">
                 <input
@@ -102,4 +103,28 @@
     {{ end }}
     <a type="button" class="btn btn-light" href="/accounts">Cancel</a>
 </form>
+
+<script>
+    $(document).ready(function () {
+        const $select = $("#accountTypeID");
+        const $interestRow = $("#interestRateRow");
+        const $interestInput = $("#interestRate");
+
+        function toggleInterestRate() {
+            const ledgerType = $select
+                .find("option:selected")
+                .data("ledger-type");
+            if (ledgerType === "liability") {
+                $interestRow.show();
+                $interestInput.prop("required", true);
+            } else {
+                $interestRow.hide();
+                $interestInput.prop("required", false);
+            }
+        }
+
+        $select.on("change", toggleInterestRate);
+        toggleInterestRate(); // run once on page load (edit mode)
+    });
+</script>
 {{ template "footer"}}

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -39,7 +39,7 @@ type AccountDTO struct {
 	BalanceLastUpdated  string
 	TxnLastUpdated      string
 	InterestRate        float64 `json:"interest_rate"`
-	InterestRatePercent string `json:"interest_rate_percent"`
+	InterestRatePercent string  `json:"interest_rate_percent"`
 }
 
 type AccountsPageDTO struct {
@@ -60,7 +60,7 @@ type AccountFormDTO struct {
 	AccountTypeName string
 	AccountTypes    []models.AccountType // the DTO probably shouldn't be using the models
 	DefaultParser   string
-	InterestRate	string
+	InterestRate    string
 }
 
 func (ac *AccountController) generateAccountsView(w http.ResponseWriter, req *http.Request) {
@@ -209,9 +209,9 @@ func (ac *AccountController) upsertAccount(w http.ResponseWriter, req *http.Requ
 	accountName := req.FormValue("accountName")
 	accountTypeIDFormValue := req.FormValue("accountTypeID")
 	interestRateFormValue := req.FormValue("interestRate")
-	
+
 	var account models.Account
-	
+
 	if accountID != "" {
 		id, err := utils.StringToUint(accountID)
 		if err != nil {
@@ -249,8 +249,8 @@ func (ac *AccountController) upsertAccount(w http.ResponseWriter, req *http.Requ
 			http.Error(w, "Invalid interest rate format", http.StatusBadRequest)
 			return
 		}
-		
-    	//validate range
+
+		//validate range
 		if interestRate < 0 || interestRate > 100 {
 			http.Error(w, "Interest rate must be between 0 and 100", http.StatusBadRequest)
 			return

--- a/internal/api/accounts.go
+++ b/internal/api/accounts.go
@@ -122,10 +122,19 @@ func (ac *AccountController) generateAccountsViewContent(w http.ResponseWriter, 
 		}
 	}
 
-	sort.Slice(accountsDTO, func(i, j int) bool {
-		if accountsDTO[i].AccountCategory == "liability" && accountsDTO[j].AccountCategory == "liability" {
-			return accountsDTO[i].InterestRate > accountsDTO[j].InterestRate
+	sort.SliceStable(accountsDTO, func(j, k int) bool {
+		// Sort liabilities by descending interest rate
+		if accountsDTO[j].AccountType == "liability" && accountsDTO[k].AccountType == "liability" {
+			return accountsDTO[j].InterestRate > accountsDTO[k].InterestRate
 		}
+		// Liabilities come before non-liabilities
+		if accountsDTO[j].AccountType == "liability" {
+			return true
+		}
+		if accountsDTO[k].AccountType == "liability" {
+			return false
+		}
+		// Otherwise, keep the original order
 		return false
 	})
 	accountsPageDTO := AccountsPageDTO{

--- a/internal/api/accounts.html
+++ b/internal/api/accounts.html
@@ -1,89 +1,121 @@
 {{ template "header" .}}
 <div class="row">
-  <div class="col-sm-4">
-    <h2>Accounts</h2>
-  </div>
-  <div class="col-sm-8">
-    <button class="btn btn-success" style="float: right;"
-      hx-get="/accountForm"
-      hx-trigger="click"
-      hx-target="body"
-      hx-swap="innerHTML">
-        &#x2B; Add account
-    </button>
-  </div>
+    <div class="col-sm-4">
+        <h2>Accounts</h2>
+    </div>
+    <div class="col-sm-8">
+        <button
+            class="btn btn-success"
+            style="float: right"
+            hx-get="/accountForm"
+            hx-trigger="click"
+            hx-target="body"
+            hx-swap="innerHTML"
+        >
+            &#x2B; Add account
+        </button>
+    </div>
 </div>
 
-{{range $i, $account := .Accounts}}
-  {{/* every 4th element, start a new row */}}
-  {{if mod $i 4 | eq 0}}
-  <div class="row" style="margin-top: 1rem;">
-  {{end}}
+{{range $i, $account := .Accounts}} {{/* every 4th element, start a new row */}}
+{{if mod $i 4 | eq 0}}
+<div class="row" style="margin-top: 1rem">
+    {{end}}
     <div class="col-lg-3">
-      <div class="card category-card mb-3 shadow-sm">
-        <div class="card-header d-flex align-items-center">
-          <div class="flex-grow-1">
-            <div class="d-flex justify-content-between align-items-center mb-2">
-              <h5>{{ $account.Name }}</h5>
-              <div>
-                <a href="#"
-                  class="btn btn-light"
-                  hx-get="/accountForm?accountID={{ $account.ID }}"
-                  hx-trigger="click"
-                  hx-target="body"
-                  hx-swap="innerHTML">
-                  &#x1F58B; Edit
-                </a>
-              </div>
+        <div class="card category-card mb-3 shadow-sm">
+            <div class="card-header d-flex align-items-center">
+                <div class="flex-grow-1">
+                    <div
+                        class="d-flex justify-content-between align-items-center mb-2"
+                    >
+                        <h5>{{ $account.Name }}</h5>
+                        <div>
+                            <a
+                                href="#"
+                                class="btn btn-light"
+                                hx-get="/accountForm?accountID={{ $account.ID }}"
+                                hx-trigger="click"
+                                hx-target="body"
+                                hx-swap="innerHTML"
+                            >
+                                &#x1F58B; Edit
+                            </a>
+                        </div>
+                    </div>
+                </div>
             </div>
-          </div>
+            <div class="card-body">
+                <h5>Balance: ${{ $account.Balance }}</h5>
+                <p>Balance last updated: {{ $account.BalanceLastUpdated }}</p>
+                <p>Transaction last updated: {{ $account.TxnLastUpdated }}</p>
+                {{if gt $account.InterestRate 0.0}}
+                <p>
+                    <span
+                        class="badge 
+                {{if gt $account.InterestRate 0.15}}bg-danger
+                {{else if gt $account.InterestRate 0.08}}bg-warning text-dark
+                {{else}}bg-success{{end}}"
+                    >
+                        {{ $account.InterestRatePercent }}
+                    </span>
+                    {{if and (eq $account.AccountCategory "liability") (gt
+                    $account.InterestRate 0.15)}}
+                    <small class="text-danger fw-bold ms-2"
+                        >Priority: Pay off first!</small
+                    >
+                    {{end}}
+                </p>
+                {{end}}
+                <a
+                    href="#"
+                    class="btn btn-light"
+                    hx-get="/transactions?accountID={{ $account.ID }}"
+                    hx-trigger="click"
+                    hx-target="body"
+                    hx-swap="innerHTML"
+                >
+                    Transactions
+                </a>
+                <a
+                    href="#"
+                    class="btn btn-light"
+                    hx-get="/balances?accountID={{ $account.ID }}"
+                    hx-trigger="click"
+                    hx-target="body"
+                    hx-swap="innerHTML"
+                >
+                    Balances
+                </a>
+            </div>
         </div>
-        <div class="card-body">
-          <h5>Balance: ${{ $account.Balance }}</h5>
-          <p>Balance last updated: {{ $account.BalanceLastUpdated }}</p>
-          <p>Transaction last updated: {{ $account.TxnLastUpdated }}</p>
-          <a href="#"
-            class="btn btn-light"
-            hx-get="/transactions?accountID={{ $account.ID }}"
-            hx-trigger="click"
-            hx-target="body"
-            hx-swap="innerHTML">
-            Transactions
-          </a>
-          <a href="#"
-            class="btn btn-light"
-            hx-get="/balances?accountID={{ $account.ID }}"
-            hx-trigger="click"
-            hx-target="body"
-            hx-swap="innerHTML">
-            Balances  
-          </a>
-        </div>
-      </div>
     </div>
-  {{/* after every 4th element, end the row */}}
-  {{if mod $i 4 | eq 3 }}
-  </div>
-  {{end}}
-{{end}}
-
-{{ if eq .AccountUpdated true }}
+    {{/* after every 4th element, end the row */}} {{if mod $i 4 | eq 3 }}
+</div>
+{{end}} {{end}} {{ if eq .AccountUpdated true }}
 <div class="toast-container position-fixed bottom-0 end-0 p-3">
-  <div id="accountUpdatedToast" class="toast" role="alert" aria-live="assertive" aria-atomic="true">
-    <div class="toast-header">
-      <strong class="me-auto">Account updated</strong>
-      <small>Just now</small>
-      <button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="Close"></button>
+    <div
+        id="accountUpdatedToast"
+        class="toast"
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+    >
+        <div class="toast-header">
+            <strong class="me-auto">Account updated</strong>
+            <small>Just now</small>
+            <button
+                type="button"
+                class="btn-close"
+                data-bs-dismiss="toast"
+                aria-label="Close"
+            ></button>
+        </div>
+        <div class="toast-body">{{ .AccountUpdatedMessage }}</div>
     </div>
-    <div class="toast-body">
-      {{ .AccountUpdatedMessage }}
-    </div>
-  </div>
 </div>
 <script>
-  toastLiveExample = document.getElementById('accountUpdatedToast')
-  toast = new bootstrap.Toast(toastLiveExample)
-  toast.show()
+    toastLiveExample = document.getElementById("accountUpdatedToast");
+    toast = new bootstrap.Toast(toastLiveExample);
+    toast.show();
 </script>
-{{ end }}
-{{ template "footer"}}
+{{ end }} {{ template "footer"}}

--- a/internal/api/accounts.html
+++ b/internal/api/accounts.html
@@ -58,7 +58,7 @@
                     >
                         {{ $account.InterestRatePercent }}
                     </span>
-                    {{if and (eq $account.AccountCategory "liability") (gt
+                    {{if and (eq $account.AccountType "liability") (gt
                     $account.InterestRate 0.15)}}
                     <small class="text-danger fw-bold ms-2"
                         >Priority: Pay off first!</small

--- a/internal/models/account.go
+++ b/internal/models/account.go
@@ -22,9 +22,10 @@ type AccountRepository struct {
 
 func (ar *AccountRepository) GetAllAccounts() ([]Account, error) {
 	var accounts []Account
-	result := ar.DB.Find(&accounts)
+	result := ar.DB.Preload("AccountType").Find(&accounts)
 	return accounts, result.Error
 }
+
 
 func (ar *AccountRepository) GetAccountByID(id uint) (Account, error) {
 	var account Account

--- a/internal/models/account.go
+++ b/internal/models/account.go
@@ -26,7 +26,6 @@ func (ar *AccountRepository) GetAllAccounts() ([]Account, error) {
 	return accounts, result.Error
 }
 
-
 func (ar *AccountRepository) GetAccountByID(id uint) (Account, error) {
 	var account Account
 	result := ar.DB.Preload(clause.Associations).Where("id = ?", id).Find(&account)

--- a/internal/models/account.go
+++ b/internal/models/account.go
@@ -13,6 +13,7 @@ type Account struct {
 	Name          string
 	AccountTypeID uint
 	AccountType   AccountType
+	InterestRate  float64 `gorm:"type:decimal(5,4);default:0.0000" json:"interest_rate"`
 }
 
 type AccountRepository struct {

--- a/sql-prototype/accounts_ddl.sql
+++ b/sql-prototype/accounts_ddl.sql
@@ -2,9 +2,17 @@
 
 DROP TABLE IF EXISTS accounts;
 
-CREATE TABLE accounts (id int PRIMARY KEY, name TEXT NOT NULL, account_type TEXT NOT NULL, charge_type TEXT NOT NULL);
+CREATE TABLE accounts (
+    id int PRIMARY KEY, 
+    name TEXT NOT NULL, 
+    account_type TEXT NOT NULL, 
+    charge_type TEXT NOT NULL,
+    interest_rate DECIMAL(5,4) DEFAULT 0.0000
+);
 
 INSERT INTO accounts
 (id, name, account_type, charge_type)
 VALUES
-(1, 'schwaby', 'checking', 'asset');
+(1, 'schwaby', 'checking', 'asset', 0.0000),
+(2, 'credit_card', 'credit', 'liability', 0.1899),
+(3, 'mortgage', 'mortgage', 'liability', 0.0650);


### PR DESCRIPTION
## Overview
This PR implements the functionality requested in issue #76 to allow users to specify interest rates on liability accounts and use this data to recommend which debt to pay off first.

## Changes Made

### Backend Changes
- Added `InterestRate` field to `Account` model with GORM `decimal(5,4)` type
- Updated `AccountDTO` and `AccountFormDTO` to include interest rate fields
- Enhanced `upsertAccount` handler to process and validate interest rate input
- Added interest rate conversion logic (percentage to decimal) with validation (0-100%)
- Implemented sorting logic to prioritize liability accounts by interest rate

### Frontend Changes
- Added interest rate input field to account creation/edit form with Bootstrap floating labels
- Updated account cards to display interest rates with color-coded badges:
  - **Red badge**: >15% interest rate (high priority)
  - **Yellow badge with dark text**: 8-15% interest rate (medium priority)  
  - **Green badge**: 0-8% interest rate (low priority)
- Added visual card borders matching badge colors for quick identification
- Included "Priority: Pay off first!" indicator for high-interest debt
- Only displays interest rate if > 0% to avoid clutter

### Database Changes
- GORM auto-migration adds `interest_rate` column with default value 0.0000
- Updated SQL prototype to include interest rate field for consistency

## Debt Prioritization Features
- Liability accounts are automatically sorted by interest rate (highest first)
- Visual styling helps users quickly identify which debts need attention
- Clear priority messaging for high-interest debt (>15%)

## Testing
- [x] Create new liability accounts with interest rates
- [x] Edit existing liability accounts to add interest rates  
- [x] Verify sorting of liability accounts by interest rate
- [x] Validate interest rate input constraints (0-100%)
- [x] Confirm visual styling for different interest rate ranges

Closes #76